### PR TITLE
Attraction Manager, Attraction Scriptable Object changes

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -341,9 +341,59 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1720828594
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1720828596}
+  - component: {fileID: 1720828595}
+  m_Layer: 0
+  m_Name: AttractionManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1720828595
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1720828594}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 947f43f869853714a942274efbe2e21d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  attractionsInput:
+  - {fileID: 11400000, guid: 8ef9d89cd3c99d544b163129dd0b6647, type: 2}
+  - {fileID: 11400000, guid: 16946d6b08da2b543a5742f783790e70, type: 2}
+  - {fileID: 11400000, guid: 8ef9d89cd3c99d544b163129dd0b6647, type: 2}
+  - {fileID: 11400000, guid: 16946d6b08da2b543a5742f783790e70, type: 2}
+--- !u!4 &1720828596
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1720828594}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
   m_Roots:
   - {fileID: 519420032}
   - {fileID: 619394802}
+  - {fileID: 1720828596}

--- a/Assets/ScriptableObjects.meta
+++ b/Assets/ScriptableObjects.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 94ae27c08a16018469319fc99d03332f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableObjects/AttractionGeneric.asset
+++ b/Assets/ScriptableObjects/AttractionGeneric.asset
@@ -1,0 +1,22 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ad40b6ad4aa7abf47adf02d79cab0ed2, type: 3}
+  m_Name: AttractionGeneric
+  m_EditorClassIdentifier: 
+  attractionType: 0
+  name: genericy
+  description: Generic
+  aoeRadius: 1
+  aoeMaxAffectedPeople: 1
+  recoveryTime: 0
+  health: 100
+  attackDamage: 1

--- a/Assets/ScriptableObjects/AttractionGeneric.asset.meta
+++ b/Assets/ScriptableObjects/AttractionGeneric.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8ef9d89cd3c99d544b163129dd0b6647
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableObjects/AttractionGhost.asset
+++ b/Assets/ScriptableObjects/AttractionGhost.asset
@@ -1,0 +1,22 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ad40b6ad4aa7abf47adf02d79cab0ed2, type: 3}
+  m_Name: AttractionGhost
+  m_EditorClassIdentifier: 
+  attractionType: 3
+  name: Ghosty
+  description: Ghost
+  aoeRadius: 1
+  aoeMaxAffectedPeople: 1
+  recoveryTime: 0
+  health: 100
+  attackDamage: 1

--- a/Assets/ScriptableObjects/AttractionGhost.asset.meta
+++ b/Assets/ScriptableObjects/AttractionGhost.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 16946d6b08da2b543a5742f783790e70
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/AttractionManager.cs
+++ b/Assets/Scripts/AttractionManager.cs
@@ -1,0 +1,68 @@
+using System.Collections;
+using System.Collections.Generic;
+using Unity.VisualScripting;
+using UnityEngine;
+
+public class AttractionManager : MonoBehaviour
+{
+    // List vs array: List is more flexible, array is faster
+    // List is a class, array is a struct
+    //public List<AttractionScriptableObject> attractions;
+    public AttractionScriptableObject[] attractionsInput;
+    private AttractionScriptableObject[] attractionObjects;
+
+    // Awake is called when the script instance is being loaded
+    void Awake()
+    {
+        attractionObjects = new AttractionScriptableObject[attractionsInput.Length];
+        for (int i = 0; i < attractionsInput.Length; i++)
+        {
+            attractionObjects[i] = Object.Instantiate(attractionsInput[i]);            
+        }
+        for (int i = 0; i < attractionObjects.Length; i++)
+        {
+            AttractionScriptableObject attraction = attractionObjects[i];
+            Debug.Log("Attraction " + attraction.name + " health: " + attraction.health);
+        }
+    }
+
+    // Start is called before the first frame update
+    void Start()
+    {
+        /*
+        Debug.Log("AttractionManager->Start()");
+        foreach (var attraction in attractions)
+        {
+            // Perform operations on each attraction
+            Debug.Log(attraction.name);
+        }
+        */
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        for(int i = attractionObjects.Length -1; i >= 0; i--)
+        {
+            AttractionScriptableObject attraction = attractionObjects[i];
+            if (attraction == null)
+            {
+                continue;
+            }
+            attraction.health -= 1;
+            if (attraction.health <= 0)
+            {
+                Debug.Log("Attraction destroyed: " + attraction.name);
+                // Destroy attraction
+                // Animate destruction
+                attractionObjects[i] = null;
+                //attractions.RemoveAt(i);
+                // Can't destroy assets, need game objects
+                //Destroy(attraction);
+            }
+            Debug.Log("Attraction " + attraction.name + " health: "+ attraction.health);
+        }
+        // Can't destroy List objects in a foreach loop without possible bugs
+        //foreach (var attraction in attractions) {}
+    }
+}

--- a/Assets/Scripts/AttractionManager.cs.meta
+++ b/Assets/Scripts/AttractionManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 947f43f869853714a942274efbe2e21d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/AttractionScriptableObject.cs
+++ b/Assets/Scripts/AttractionScriptableObject.cs
@@ -1,9 +1,8 @@
-using System.Collections;
-using System.Collections.Generic;
+using System;
 using UnityEngine;
 
 
-[CreateAssetMenu(fileName = "Attraction", menuName = "Attractions")]
+[CreateAssetMenu(fileName = "Attraction", menuName = "Scriptable Objects/Attractions")]
 public class AttractionScriptableObject : ScriptableObject {
     
     public Nightmares.AttractionTypes attractionType;
@@ -11,22 +10,36 @@ public class AttractionScriptableObject : ScriptableObject {
 	public new string name;
 	public string description;
 
-    public float aoeRadius;
-    public int aoeMaxAffectedPeople;
+    [Range(1, 4)]
+    [Tooltip("Area of Effect: 1 ~ 1 tiles")]
+    public float aoeRadius = 1.0f;
+    [Range(1, 4)]
+    [Tooltip("Area of Effect: # people")]
+    public uint aoeMaxAffectedPeople = 1;
 
-    bool triggering;
-    float lastTriggerTime;
     public float recoveryTime; // activate, recover, activate again
-    
-    public int health;
-    public int attackDamage;
+
+    // [SerializeField]: Expose private variables to Unity Editor
+    public int health = 100;
+    public int attackDamage = 1;
 
     // optional, at creation or when "Reset" is performed
-/*    void Reset() {
-        Debug.Log("Created/Reset");
-        triggering = false;
-        health = 100;
-        damage = 50;
+    // NOTE: Within the editor at least, changes are saved to the asset??
+    /*    void Reset() {
+            Debug.Log("Created/Reset");
+            triggering = false;
+            health = 100;
+            damage = 50;
+        }
+    */
+    private void OnEnable()
+    {
+        Debug.Log("OnEnable()");
+        //health = 100;
+        //attackDamage = 1;        
     }
-*/
+    private void OnDisable()
+    {
+        Debug.Log("OnDisable()");
+    }
 }

--- a/Assets/Scripts/BootInitializer.cs
+++ b/Assets/Scripts/BootInitializer.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
+using UnityEditor;
 using UnityEngine;
 
 // "Unity Tip: Don’t use your first scene for global Script initialization - Low Scope Blog"
@@ -20,7 +21,14 @@ public class BootInitializer : MonoBehaviour {
         foreach(Nightmares.Fears fear in fears)
             Debug.Log(fear.ToString());
 
-        //GameObject nuggetGlobals = GameObject.Instantiate(Resources.Load("NuggetGlobals")) as GameObject;
-        //GameObject.DontDestroyOnLoad(nuggetGlobals);
+    /*
+        // Load all AttractionScriptableObjects
+        string[] scriptableObjects = AssetDatabase.FindAssets("t:AttractionScriptableObject");
+        // Loop through, display names of attractions
+        foreach(string so in scriptableObjects) {
+            AttractionScriptableObject attraction = AssetDatabase.LoadAssetAtPath<AttractionScriptableObject>(AssetDatabase.GUIDToAssetPath(so));
+            Debug.Log(attraction.name);
+        }
+    */
     } 
 }

--- a/Assets/Scripts/Nightmares.cs
+++ b/Assets/Scripts/Nightmares.cs
@@ -1,8 +1,8 @@
 using System.Collections.Generic;
 
-//namespace NuggetGlobals {} // initial idea to place Enums; better in a class which uses the enums
+//namespace NightmareGlobals {} // initial idea to place Enums; better in a class which uses the enums
 
-// NuggetFearsAndAttractionsUtilityClass?
+// UtilityClass
 
 public static class Nightmares {
 
@@ -27,7 +27,7 @@ public static class Nightmares {
         HP_ATTRACTION_DAMAGE_DEFAULT, HP_ATTRACTION_DAMAGE_DEFAULT, HP_ATTRACTION_DAMAGE_DEFAULT };
     
 
-    // One instance of this for all objects (NEEDS SINGLETON check! (in Awake)):
+    // One instance of this for all objects (NEEDS Initialize()!):
     static List<Fears>[] fearsForAttraction;    // = new List<Fears>[(int)AttractionTypes.OOB]; // initialized in Awake()
 
     public static uint GetHPDefaultForAttraction(AttractionTypes attractionType)


### PR DESCRIPTION
Attraction Manager initial experiments
Attraction Scriptable Object is now treated purely as a set of "initial values" to create new objects with. Otherwise the asset is changed through scenes and runs, but also behaves differently for compiled builds! Strange dual behavior. I don't trust it! Added 'HP damage' loop to Object in SampleScene that destroys multiple attractions