### PR TITLE
AttractionManager major Instantiation changes, RandomSpawnTest

### DIFF
--- a/Assets/Resources/Attractions/SkeletonPopup.prefab
+++ b/Assets/Resources/Attractions/SkeletonPopup.prefab
@@ -18,7 +18,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &2220219865091669992
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Resources/Attractions/SpiderDrop.prefab
+++ b/Assets/Resources/Attractions/SpiderDrop.prefab
@@ -18,7 +18,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &7580908415254361646
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -385,6 +385,50 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1727354588
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1727354590}
+  - component: {fileID: 1727354589}
+  m_Layer: 0
+  m_Name: CreateAttractions
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1727354589
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1727354588}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 16781111dcc99064b8021028c148a414, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &1727354590
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1727354588}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
@@ -392,3 +436,4 @@ SceneRoots:
   - {fileID: 519420032}
   - {fileID: 619394802}
   - {fileID: 1720828596}
+  - {fileID: 1727354590}

--- a/Assets/Scripts/AttractionManager.cs
+++ b/Assets/Scripts/AttractionManager.cs
@@ -8,9 +8,10 @@ public class AttractionManager : MonoBehaviour
     //public List<AttractionScriptableObject> attractions;
     //public AttractionScriptableObject[] attractionsInput;
     //private AttractionScriptableObject[] attractionObjects;
-    protected List<GameObject> attractionPrefabs;
+    //private List<GameObject> attractionPrefabs;
+    private List<GameObject> attractionPrefabInstances;
 
-    private List<GameObject> attractionGameObjects;
+    public List<GameObject> attractionGameObjects { get; private set; }
 
     // Awake is called when the script instance is being loaded
     void Awake()
@@ -28,20 +29,37 @@ public class AttractionManager : MonoBehaviour
         }
         */
         // Important: Make sure these are in the Resource\Attractions folder
-        attractionPrefabs = new List<GameObject>(Resources.LoadAll<GameObject>("Attractions"));
+        List<GameObject> attractionPrefabs = new List<GameObject>(Resources.LoadAll<GameObject>("Attractions"));
+        attractionPrefabInstances = new List<GameObject>();
         attractionGameObjects = new List<GameObject>();
+        // Have to instantiate the prefabs to be able to look at components
+        // I immediately SetActive(false) to avoid rendering and execution
+        foreach (var prefab in attractionPrefabs)
+        {
+            GameObject go = Instantiate<GameObject>(prefab, new Vector2(10000, 10000), Quaternion.identity);
+            go.SetActive(false);
+            attractionPrefabInstances.Add(go);
+            Debug.Log(prefab.name);
+        }
+        
     }
 
     public GameObject FindAttractionByType(Nightmares.AttractionTypes type)
     {
-        foreach (var go in attractionGameObjects)
+        foreach (var go in attractionPrefabInstances) //attractionPrefabs)
         {
+            // SetActive(true) to be able to look at components
+            go.SetActive(true);
             // Assuming each GameObject has a component that holds the type information
             var attractionComponent = go.GetComponent<AttractionBase>();
             if (attractionComponent != null && attractionComponent.attractionObject.attractionType == type)
             {
+                // SetActive(false) to avoid rendering and execution
+                go.SetActive(false);
                 return go;
             }
+            // SetActive(false) to avoid rendering and execution
+            go.SetActive(false);
         }
         // not found
         Debug.LogError("Attraction type not found: " + type);
@@ -49,16 +67,22 @@ public class AttractionManager : MonoBehaviour
     }
     public GameObject FindAttractionByName(string name)
     {
-        foreach (var go in attractionGameObjects)
+        foreach (var go in attractionPrefabInstances) //attractionPrefabs)
         {
+            // SetActive(true) to be able to look at components
+            go.SetActive(true);
             // Assuming each GameObject has a component that holds the type information
             var attractionComponent = go.GetComponent<AttractionBase>();
             if (attractionComponent != null &&
                 string.Compare(attractionComponent.attractionObject.name, name,
                 System.StringComparison.OrdinalIgnoreCase) == 0)
             {
+                // SetActive(false) to avoid rendering and execution
+                go.SetActive(false);
                 return go;
             }
+            // SetActive(false) to avoid rendering and execution
+            go.SetActive(false);
         }
         // not found
         Debug.LogError("Attraction named '" + name + "' not found");
@@ -68,6 +92,7 @@ public class AttractionManager : MonoBehaviour
     {
         GameObject go = Instantiate<GameObject>(prefab, position, Quaternion.identity);
         attractionGameObjects.Add(go);
+        go.SetActive(true);
         return go;
     }
     public GameObject SpawnAttractionByType(Nightmares.AttractionTypes type, Vector2 position)
@@ -106,6 +131,7 @@ public class AttractionManager : MonoBehaviour
             Debug.Log(attraction.name);
         }
         */
+/*
         foreach (var prefab in attractionPrefabs)
         {
             // Perform operations on each attraction
@@ -119,6 +145,7 @@ public class AttractionManager : MonoBehaviour
             //attractionGameObjects.Add(go);
         }
         SpawnAttractionByType(Nightmares.AttractionTypes.SpiderDrop, new Vector2(2, 1));
+*/
     }
 
     // Update is called once per frame

--- a/Assets/Scripts/AttractionRandomSpawnTest.cs
+++ b/Assets/Scripts/AttractionRandomSpawnTest.cs
@@ -1,0 +1,45 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class AttractionRandomSpawnTest : MonoBehaviour
+{
+    // Spawn attractions at random positions
+    void SpawnRandomAttractions()
+    {
+        Debug.Log("Spawning random attractions...");
+        
+        // Get the AttractionManager component from the GameObject named "AttractionManager"
+        GameObject attractionManagerObject = GameObject.Find("AttractionManager");
+        AttractionManager attractionManager = attractionManagerObject.GetComponent<AttractionManager>();
+
+        // Loop through ALL prefabs and instantiate one of each:
+        /*foreach (var prefab in attractionManager.attractionPrefabs)
+        {
+            Debug.Log(prefab.name);
+            int x = Random.Range(-3, 3);
+            int y = Random.Range(-3, 3);
+            // Important: Animations: Use Animator and Sprite Renderer components, NO Animation component!
+            // Problem with "FreezeState": Just use a 1-frame animation or an "Idle" animation and set the time to 0
+            attractionManager.SpawnAttraction(prefab, new Vector2(x, y));
+        }
+        */
+        
+        // Spawn a specific attraction by type
+        attractionManager.SpawnAttractionByType(Nightmares.AttractionTypes.SpiderDrop, new Vector2(2, 1));
+        attractionManager.SpawnAttractionByType(Nightmares.AttractionTypes.SkeletonPopUp, new Vector2(2, 2));
+        // Spawn a specific attraction by name
+        attractionManager.SpawnAttractionByName("SpiderDrop", new Vector2(1, 2));
+    }
+    // Start is called before the first frame update
+    void Start()
+    {
+        SpawnRandomAttractions();   
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        
+    }
+}

--- a/Assets/Scripts/AttractionRandomSpawnTest.cs.meta
+++ b/Assets/Scripts/AttractionRandomSpawnTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 16781111dcc99064b8021028c148a414
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
AttractionManager wasn't letting me query Components without instantiating an object and setting it to Active, which causes much pain.  Probably better to not 'add by type' or name and just add directly from the prefab file names
AttractionSpawnTest created to show how to use things currently
Set 'active' status on prefabs to inactive, not that it seems to change anything