### PR TITLE
Attraction SO fix, Nugget freakout AOE transparency

### DIFF
--- a/Assets/Resources/Prefabs/Nugget.prefab
+++ b/Assets/Resources/Prefabs/Nugget.prefab
@@ -76,7 +76,7 @@ SpriteRenderer:
   m_SortingLayer: 0
   m_SortingOrder: -1
   m_Sprite: {fileID: -2413806693520163455, guid: a86470a33a6bf42c4b3595704624658b, type: 3}
-  m_Color: {r: 1, g: 1, b: 1, a: 0.4117647}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.19607843}
   m_FlipX: 0
   m_FlipY: 0
   m_DrawMode: 0

--- a/Assets/ScriptableObjects/AttractionSkeleton.asset
+++ b/Assets/ScriptableObjects/AttractionSkeleton.asset
@@ -17,7 +17,7 @@ MonoBehaviour:
   description: SkeletonPopUp description
   aoeRadius: 1
   activationTime: 2
-  recoveryTime: 1
+  recoveryTime: 2
   startHealth: 100
   attackDamage: 5
   animator: {fileID: 9100000, guid: 39bd656105e81d84483b62fb0d1231a8, type: 2}

--- a/Assets/ScriptableObjects/AttractionSpider.asset
+++ b/Assets/ScriptableObjects/AttractionSpider.asset
@@ -17,7 +17,7 @@ MonoBehaviour:
   description: SpiderDrop description
   aoeRadius: 1
   activationTime: 2
-  recoveryTime: 1
+  recoveryTime: 2
   startHealth: 100
   attackDamage: 5
   animator: {fileID: 9100000, guid: e1781176bc76f694c98a07728bbf3854, type: 2}

--- a/Assets/Scripts/AttractionScriptableObject.cs
+++ b/Assets/Scripts/AttractionScriptableObject.cs
@@ -56,8 +56,8 @@ public class AttractionScriptableObject : ScriptableObject {
     // Called on Creation or when "Reset" is clicked.
     void Reset()
     {
-            //Debug.Log("Created/Reset");
-            SetValuesPerAttractionType(attractionType);
+        //Debug.Log("Created/Reset");
+        //SetValuesPerAttractionType(attractionType);
     }
 
     // Validate() is called only in Editor Mode. (use to ensure values are within range)
@@ -72,6 +72,7 @@ public class AttractionScriptableObject : ScriptableObject {
             Debug.LogWarning("Area of Effect: Radius cannot be greater than 3");
             aoeRadius = 3;
         }*/
+/*        
 #if UNITY_EDITOR        
         if (attractionType != attractionTypePrev)
         {
@@ -80,6 +81,7 @@ public class AttractionScriptableObject : ScriptableObject {
             //Debug.Log("New attractionType: " + attractionType.ToString());
         }
 #endif
+*/
     }
 /*
     private void OnEnable()


### PR DESCRIPTION
Attraction Scriptable Object was wiping out attack damage in the 'convenience' functions so those are gone
Nugget freakout AOE transparency increased, not as bright